### PR TITLE
LSWI-945 Adding semaphore recipe to rdbi.

### DIFF
--- a/src/main/java/com/lithium/dbi/rdbi/Handle.java
+++ b/src/main/java/com/lithium/dbi/rdbi/Handle.java
@@ -9,7 +9,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import java.io.Closeable;
 
 @NotThreadSafe
-public class Handle implements Closeable, AutoCloseable {
+public class Handle implements Closeable {
 
     private final Pool<Jedis> pool;
     private final Jedis jedis;

--- a/src/main/java/com/lithium/dbi/rdbi/recipes/locking/RedisSemaphore.java
+++ b/src/main/java/com/lithium/dbi/rdbi/recipes/locking/RedisSemaphore.java
@@ -1,7 +1,6 @@
 package com.lithium.dbi.rdbi.recipes.locking;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import com.lithium.dbi.rdbi.Handle;
 import com.lithium.dbi.rdbi.RDBI;
 
@@ -19,16 +18,14 @@ public class RedisSemaphore {
     public boolean acquireSemaphore(final Integer semaphoreExpireSeconds) {
         try (Handle handle = rdbi.open()) {
             return 1 == handle.attach(RedisSemaphoreDAO.class)
-                              .acquireSemaphore(ImmutableList.of(semaphoreKey),
-                                                ImmutableList.of(ownerId, semaphoreExpireSeconds.toString()));
+                              .acquireSemaphore(semaphoreKey, ownerId, semaphoreExpireSeconds);
         }
     }
 
     public Optional<String> releaseSemaphore() {
         try (Handle handle = rdbi.open()) {
             return Optional.fromNullable(handle.attach(RedisSemaphoreDAO.class)
-                                               .releaseSemaphore(ImmutableList.of(semaphoreKey),
-                                                                 ImmutableList.of(ownerId)));
+                                               .releaseSemaphore(semaphoreKey, ownerId));
         }
     }
 }


### PR DESCRIPTION
LSWI-945 Adding semaphore recipe to rdbi. This is being done to make acquire/release calls atomic to combat any redis connectivity issues. @KhaiNguyen CR please. Could either @phutwo or @cschellenger give a CR as well.
