### PR TITLE
load all cache discards keys that are no longer found in backint data…

### DIFF
--- a/src/main/java/com/lithium/dbi/rdbi/recipes/cache/AsyncCacheAllRefresher.java
+++ b/src/main/java/com/lithium/dbi/rdbi/recipes/cache/AsyncCacheAllRefresher.java
@@ -4,8 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.Callable;
 
 public class AsyncCacheAllRefresher<KeyType, ValueType> implements Callable<CallbackResult<Collection<ValueType>>> {
@@ -31,18 +29,14 @@ public class AsyncCacheAllRefresher<KeyType, ValueType> implements Callable<Call
         log.debug("{}: Attempting to refresh data", cache.getCacheName());
 
         try {
-            final Collection<ValueType> values = cache.loadAll();
+            final Collection<ValueType> values = cache.fetchAll();
             if (values == null) {
                 cache.markLoadException(System.currentTimeMillis() - start);
                 return new CallbackResult<>();
             }
 
             log.info("{}: Async refresh", cache.getCacheName());
-            Map<KeyType, ValueType> valuesMap = new HashMap<>();
-            for (ValueType value : values) {
-                valuesMap.put(cache.keyFromValue(value), value);
-            }
-            cache.putAll(valuesMap);
+            cache.applyFetchAll(values);
             cache.markLoadSuccess(System.currentTimeMillis() - start);
             cache.loadAllComplete();
             return new CallbackResult<>(values);

--- a/src/main/java/com/lithium/dbi/rdbi/recipes/cache/LoadAllCache.java
+++ b/src/main/java/com/lithium/dbi/rdbi/recipes/cache/LoadAllCache.java
@@ -15,7 +15,6 @@ public interface LoadAllCache<KeyType, ValueType> extends InstrumentedCache<KeyT
      */
     void releaseLock();
 
-
     /**
      * Derive a KeyType from a ValueType.
      * @param value
@@ -24,12 +23,16 @@ public interface LoadAllCache<KeyType, ValueType> extends InstrumentedCache<KeyT
     KeyType keyFromValue(ValueType value);
 
     /**
-     * Load all available data from the original source.
+     * Fetches all available data from the original source.
      * @return
      * @throws Exception
      */
-    Collection<ValueType> loadAll() throws Exception;
+    Collection<ValueType> fetchAll() throws Exception;
 
+    /**
+     * Apply the most recently fetched data. Evicts previously cached, but since deleted keys.
+     */
+    void applyFetchAll(Collection<ValueType> fetched);
 
     /**
      * Perform some cleanup to indicate that all available data has been loaded.


### PR DESCRIPTION
… source
