### PR TITLE
if NOSCRIPT occurs, reload the script

### DIFF
--- a/rdbi-core/src/main/java/com/lithium/dbi/rdbi/MethodContextInterceptor.java
+++ b/rdbi-core/src/main/java/com/lithium/dbi/rdbi/MethodContextInterceptor.java
@@ -69,11 +69,11 @@ class MethodContextInterceptor implements MethodInterceptor {
         try {
             return jedis.evalsha(context.getSha1(), keys, argv);
         } catch (JedisDataException e) {
-            if (e.getMessage().contains("NOSCRIPT")) {
+            if (e.getMessage() != null && e.getMessage().contains("NOSCRIPT")) {
                 //If it throws again, we can back-off or we can just let it throw again. In this case, I think we should
                 //let it throw because most likely will be trying the same thing again and hopefully it will succeed later.
-                final String sha2 = jedis.scriptLoad(context.getLuaContext().getRenderedLuaString());
-                if (!sha2.equals(context.getSha1())) {
+                final String newSha = jedis.scriptLoad(context.getLuaContext().getRenderedLuaString());
+                if (!newSha.equals(context.getSha1())) {
                     throw new IllegalStateException("sha should match but they did not");
                 }
                 return jedis.evalsha(context.getSha1(), keys, argv);

--- a/rdbi-core/src/test/java/com/lithium/dbi/rdbi/RDBITest.java
+++ b/rdbi-core/src/test/java/com/lithium/dbi/rdbi/RDBITest.java
@@ -20,7 +20,7 @@ import static org.testng.Assert.fail;
 
 public class RDBITest {
 
-    static interface TestDAO {
+    interface TestDAO {
         @Query(
             "redis.call('SET',  KEYS[1], ARGV[1]);" +
             "return 0;"
@@ -28,7 +28,7 @@ public class RDBITest {
         int testExec(List<String> keys, List<String> args);
     }
 
-    static interface TestCopyDAO {
+    interface TestCopyDAO {
         @Query(
                 "redis.call('SET',  KEYS[1], ARGV[1]);" +
                         "return 0;"
@@ -36,16 +36,16 @@ public class RDBITest {
         int testExec2(List<String> keys, List<String> args);
     }
 
-    static interface NoInputDAO {
+    interface NoInputDAO {
         @Query("return 0;")
         int noInputMethod();
     }
 
-    static interface DynamicDAO {
+    interface DynamicDAO {
         @Query(
                 "redis.call('SET', $a$, $b$); return 0;"
         )
-        int testExect(@BindKey("a") String a, @BindArg("b") String b);
+        int testExec(@BindKey("a") String a, @BindArg("b") String b);
     }
 
     static class BasicObjectUnderTest {
@@ -173,7 +173,7 @@ public class RDBITest {
         Handle handle = rdbi.open();
 
         try {
-            handle.attach(DynamicDAO.class).testExect("a", "b");
+            handle.attach(DynamicDAO.class).testExec("a", "b");
         } finally {
             handle.close();
         }
@@ -186,7 +186,7 @@ public class RDBITest {
 
         try {
             for (int i = 0; i < 2; i++) {
-                handle.attach(DynamicDAO.class).testExect("a", "b");
+                handle.attach(DynamicDAO.class).testExec("a", "b");
             }
             assertTrue(rdbi.proxyFactory.factoryCache.containsKey(DynamicDAO.class));
         } finally {

--- a/rdbi-core/src/test/resources/suites/integration.xml
+++ b/rdbi-core/src/test/resources/suites/integration.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="IntegrationTests">
+<suite name="IntegrationTests" parallel="false">
     <test name="integration">
         <groups>
             <run>

--- a/rdbi-core/src/test/resources/suites/standard.xml
+++ b/rdbi-core/src/test/resources/suites/standard.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="UnitTests">
+<suite name="UnitTests" parallel="false">
     <test name="standard">
         <groups>
             <run>

--- a/rdbi-recipes-java7/src/test/java/com/lithium/dbi/rdbi/recipes/scheduler/ExclusiveJobSchedulerTest.java
+++ b/rdbi-recipes-java7/src/test/java/com/lithium/dbi/rdbi/recipes/scheduler/ExclusiveJobSchedulerTest.java
@@ -261,11 +261,11 @@ public class ExclusiveJobSchedulerTest {
 
     @Test
     public void testReadyCountWithSomeJobsNotReadyAfterScriptFlush() throws Exception {
+        scheduledJobSystem.schedule(tubeName, "{job1}", 0);
+        //simulate reboot of redis
         try (Handle handle = rdbi.open()) {
             handle.jedis().scriptFlush();
         }
-
-        scheduledJobSystem.schedule(tubeName, "{job1}", 0);
         scheduledJobSystem.schedule(tubeName, "{job2}", 500);
         scheduledJobSystem.schedule(tubeName, "{job3}", 10000000);
 

--- a/rdbi-recipes-java7/src/test/java/com/lithium/dbi/rdbi/recipes/scheduler/ExclusiveJobSchedulerTest.java
+++ b/rdbi-recipes-java7/src/test/java/com/lithium/dbi/rdbi/recipes/scheduler/ExclusiveJobSchedulerTest.java
@@ -122,7 +122,7 @@ public class ExclusiveJobSchedulerTest {
         List<TimeJobInfo> jobInfos5 = scheduledJobSystem.peekExpired(tubeName, 0, 1);
         assertEquals(jobInfos5.get(0).getJobStr(), "{hello:world}");
 
-        scheduledJobSystem.deleteJob(tubeName,  "{hello:world}");
+        scheduledJobSystem.deleteJob(tubeName, "{hello:world}");
         assertEquals(scheduledJobSystem.peekDelayed(tubeName, 1, 0).size(), 0);
         assertEquals(scheduledJobSystem.peekReady(tubeName, 1, 0).size(), 0);
         assertEquals(scheduledJobSystem.peekRunning(tubeName, 1, 0).size(), 0);
@@ -241,6 +241,30 @@ public class ExclusiveJobSchedulerTest {
 
     @Test
     public void testReadyCountWithSomeJobsNotReady() throws Exception {
+        scheduledJobSystem.schedule(tubeName, "{job1}", 0);
+        scheduledJobSystem.schedule(tubeName, "{job2}", 500);
+        scheduledJobSystem.schedule(tubeName, "{job3}", 10000000);
+
+        assertEquals(scheduledJobSystem.getReadyJobCount(tubeName), 1);
+
+        scheduledJobSystem.reserveSingle(tubeName, 10000);
+
+        assertEquals(scheduledJobSystem.getReadyJobCount(tubeName), 0);
+
+        Thread.sleep(500);
+
+        assertEquals(scheduledJobSystem.getReadyJobCount(tubeName), 1);
+
+        scheduledJobSystem.reserveSingle(tubeName, 10000);
+        assertEquals(scheduledJobSystem.getReadyJobCount(tubeName), 0);
+    }
+
+    @Test
+    public void testReadyCountWithSomeJobsNotReadyAfterScriptFlush() throws Exception {
+        try (Handle handle = rdbi.open()) {
+            handle.jedis().scriptFlush();
+        }
+
         scheduledJobSystem.schedule(tubeName, "{job1}", 0);
         scheduledJobSystem.schedule(tubeName, "{job2}", 500);
         scheduledJobSystem.schedule(tubeName, "{job3}", 10000000);


### PR DESCRIPTION
When Redis fails over or reboots, the scripts may be lost, since we've already
loaded them in local memory, we assume the script is already there. In the event
that they're no longer there, reload from memory and retry once