### PR TITLE
Do not try to access non-existent elements in array

### DIFF
--- a/rdbi-recipes-java7/src/main/java/com/lithium/dbi/rdbi/recipes/scheduler/ExclusiveJobSchedulerDAO.java
+++ b/rdbi-recipes-java7/src/main/java/com/lithium/dbi/rdbi/recipes/scheduler/ExclusiveJobSchedulerDAO.java
@@ -34,7 +34,7 @@ public interface ExclusiveJobSchedulerDAO {
         "if isPaused or next(jobs) == nil then\n" +
         "    return nil\n" +
         "end\n" +
-        "for i=1,2*#jobs,2 do\n" +
+        "for i=1,#jobs,2 do\n" +
         "    redis.call('ZREM', $readyQueue$, jobs[i])\n" + //Note: in order to support "limit", we have to loop the delete, perhaps not have limit, 1 at a time?
         "    redis.call('ZADD', $runningQueue$, $ttr$, jobs[i])\n" +
         "end\n" +

--- a/rdbi-recipes-java7/src/main/java/com/lithium/dbi/rdbi/recipes/scheduler/JobSchedulerDAO.java
+++ b/rdbi-recipes-java7/src/main/java/com/lithium/dbi/rdbi/recipes/scheduler/JobSchedulerDAO.java
@@ -60,7 +60,7 @@ public interface JobSchedulerDAO {
         "end\n" +
         "local reserved = {}\n" +
         "local reservedIndex = 1\n" +
-        "for i=1,2*#jobs,2 do\n" +
+        "for i=1,#jobs,2 do\n" +
         "    local runningJob = redis.call('ZSCORE', $runningQueue$, jobs[i])\n" +
         "    if not runningJob then\n" +
         "        reserved[reservedIndex] = jobs[i]\n" +
@@ -92,7 +92,7 @@ public interface JobSchedulerDAO {
     @Mapper(JobInfoListMapper.class)
     @Query(
         "local expiredJobs = redis.call('ZRANGEBYSCORE', $runningQueue$, 0, $timestamp$, 'WITHSCORES')\n" +
-        "for i=1,2*#expiredJobs,2 do\n" +
+        "for i=1,#expiredJobs,2 do\n" +
         "    redis.call('ZADD', $readyQueue$, $newScore$, expiredJobs[i])\n" +
         "end\n" +
         "redis.call('ZREMRANGEBYSCORE', $runningQueue$, 0, $timestamp$)\n" +

--- a/rdbi-recipes-java7/src/main/java/com/lithium/dbi/rdbi/recipes/scheduler/StateDedupedJobSchedulerDAO.java
+++ b/rdbi-recipes-java7/src/main/java/com/lithium/dbi/rdbi/recipes/scheduler/StateDedupedJobSchedulerDAO.java
@@ -67,7 +67,7 @@ public interface StateDedupedJobSchedulerDAO {
         "   if next(jobs) == nil then\n" +
         "       return reserved\n" +
         "   end\n" +
-        "   for i=1,2*#jobs,2 do\n" +
+        "   for i=1,#jobs,2 do\n" +
         "      local inRunningQueue = redis.call('ZSCORE', $runningQueue$, jobs[i])\n" +
         "      if not inRunningQueue then\n" +
         "          reserved[reservedIndex] = jobs[i]\n" +


### PR DESCRIPTION
In the latest version of redis, this behavior results in errors. We only need to range from 1 to the end of the list, skipping the score elements.