### PR TITLE
    Found an issue with bulk get where empty results were being retur…

### DIFF
--- a/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/channel/ChannelLuaReceiver.java
+++ b/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/channel/ChannelLuaReceiver.java
@@ -74,7 +74,7 @@ public class ChannelLuaReceiver implements ChannelReceiver {
             "        current_count = tonumber(current_count)\n" +
             "    end\n" +
             "    if current_count <= tonumber(ARGV[i+1]) then\n" +
-            "        bulk_result[i] = tostring(0)\n" +
+            "        bulk_result[i] = {}\n" +
             "    else\n" +
             "        local results = redis.call(\"LRANGE\", KEYS[i*2-1], 0, current_count - tonumber(ARGV[i+1]) + 1)\n" +
             "        results[#results + 1] = tostring(current_count)\n" +
@@ -140,6 +140,11 @@ public class ChannelLuaReceiver implements ChannelReceiver {
             List<Long> listsSizes = new ArrayList<>();
 
             for (List<String> each: result) {
+                if (each.size() == 0) {
+                    listsResult.add(each);
+                    listsSizes.add(0L);
+                    continue;
+                }
                 listsResult.add(Lists.reverse(each.subList(0, each.size() - 1)));
                 listsSizes.add(Long.valueOf(each.get(each.size()-1)));
             }

--- a/rdbi-recipes/src/test/java/com/lithium/dbi/rdbi/recipes/channel/ChannelLuaReceiverTest.java
+++ b/rdbi-recipes/src/test/java/com/lithium/dbi/rdbi/recipes/channel/ChannelLuaReceiverTest.java
@@ -137,6 +137,31 @@ public class ChannelLuaReceiverTest {
     }
 
     @Test
+    public void testEmptyChannelPublishAndReceive() throws Exception {
+
+
+        final List<String> channels = ImmutableList.of("channel1");
+        final Set<String> channelSet = ImmutableSet.of("channel1");
+        final List<Long> lastSeenIds = ImmutableList.of(0L);
+
+        RDBI rdbi = new RDBI(new JedisPool("localhost"));
+
+
+        final ChannelPublisher channelPublisher = new ChannelPublisher(rdbi);
+        channelPublisher.resetChannels(channelSet);
+
+        final int messageAmount = 0;
+
+        final ChannelReceiver channelReceiver = new ChannelLuaReceiver(rdbi);
+        GetBulkResult result = channelReceiver.getMulti(channels, lastSeenIds);
+
+        assertEquals(result.getMessages().get(0).size(), messageAmount);
+
+        channelPublisher.resetChannels(channelSet);
+
+    }
+
+    @Test
     public void testMultiThreadedMultiChannelPublishAndReceive() throws InterruptedException {
         final Set<String> channelSet = ImmutableSet.of("channel1", "channel2", "channel3", "channel4", "channel5");
         final int messageAmount = 50;


### PR DESCRIPTION
…ned as a string instead of an empty array.

    Fixed issue by updating lua script to return an array.  Added test for the case.

    Signed-off-by: Ryan Kwong <ryan.kwong@lithium.com>