### PR TITLE
prevent possible race condition by tuning cache under test to _not_ r…

### DIFF
--- a/rdbi-recipes/src/test/java/com/lithium/dbi/rdbi/recipes/cache/RedisHashCacheTest.java
+++ b/rdbi-recipes/src/test/java/com/lithium/dbi/rdbi/recipes/cache/RedisHashCacheTest.java
@@ -387,7 +387,7 @@ public class RedisHashCacheTest {
                         fetchAllFromMap(dataSource),
                         "testRemoveCache",
                         TEST_NAMESPACE,
-                        Integer.MAX_VALUE,
+                        0,
                         0,
                         Optional.of(es),
                         NOOP,


### PR DESCRIPTION
…un async cache refresh