### PR TITLE
CRUXX-580 up the expire timeout for expire and channel and depth

### DIFF
--- a/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/channel/ChannelPublisher.java
+++ b/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/channel/ChannelPublisher.java
@@ -13,7 +13,7 @@ import java.util.Set;
 public class ChannelPublisher {
 
     private static final int DEFAULT_CHANNEL_DEPTH = 100;
-    private static final int DEFAULT_CHANNEL_EXPIRE_SECONDS = 60 * 60; // 1 hour
+    private static final int DEFAULT_CHANNEL_EXPIRE_SECONDS = 30 * 24 * 60 * 60; // 30 days
 
     private final RDBI rdbi;
 

--- a/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/channel/ChannelPublisher.java
+++ b/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/channel/ChannelPublisher.java
@@ -5,6 +5,7 @@ import com.lithium.dbi.rdbi.RDBI;
 import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.Transaction;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -13,7 +14,7 @@ import java.util.Set;
 public class ChannelPublisher {
 
     private static final int DEFAULT_CHANNEL_DEPTH = 100;
-    private static final int DEFAULT_CHANNEL_EXPIRE_SECONDS = 30 * 24 * 60 * 60; // 30 days
+    private static final int DEFAULT_CHANNEL_EXPIRE_SECONDS = (int) Duration.ofDays(30).getSeconds();
 
     private final RDBI rdbi;
 


### PR DESCRIPTION
If a browser is logged in and haven't received data in one hour, the depth time
would move back and you would not get events into the UI until the next refresh