### PR TITLE
RES-2942 Circular Buffer recipe for RDBI

### DIFF
--- a/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBuffer.java
+++ b/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBuffer.java
@@ -1,0 +1,192 @@
+package com.lithium.dbi.rdbi.recipes.queue;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.lithium.dbi.rdbi.Handle;
+import com.lithium.dbi.rdbi.RDBI;
+import com.lithium.dbi.rdbi.recipes.cache.SerializationHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+
+/**
+ * A circular buffer in redis. Head of the queue is the element at index 0 in redis.
+ */
+public class RedisCircularBuffer<ValueType> implements Queue<ValueType> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisCircularBuffer.class);
+
+    private final String key;
+    private final RDBI rdbi;
+    private final SerializationHelper<ValueType> serializationHelper;
+    private final int maxSize;
+
+    public RedisCircularBuffer(final RDBI rdbi,
+                               @Nonnull final String key,
+                               final int maxSize,
+                               SerializationHelper<ValueType> serializationHelper) {
+        this.rdbi = rdbi;
+        this.key = key;
+        this.maxSize = maxSize;
+        this.serializationHelper = serializationHelper;
+        Preconditions.checkNotNull(key, "A null value was supplied for 'key'.");
+    }
+
+    @Override
+    public int size() {
+        try (final Handle handle = rdbi.open()) {
+            final Long size = handle.jedis().llen(key);
+            if (size > Integer.MAX_VALUE) {
+                LOGGER.info("size of " + key + " exceeds integer max value. .size() just lied to you.");
+                return Integer.MAX_VALUE;
+            }
+            return size.intValue();
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return containsAll(ImmutableList.of(o));
+    }
+
+    @Override
+    public Iterator<ValueType> iterator() {
+        throw new UnsupportedOperationException("iterator not supported by this circular buffer");
+    }
+
+    @Override
+    public Object[] toArray() {
+        throw new UnsupportedOperationException("toArray not supported by this circular buffer");
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        throw new UnsupportedOperationException("toArray not supported by this circular buffer");
+    }
+
+    @Override
+    public boolean add(ValueType value) {
+        return addAll(ImmutableList.of(value));
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException("removing a specific object is not supported by this circular buffer");
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        try (final Handle handle = rdbi.open()) {
+            for (final Object obj : c) {
+                final ValueType valueToFind = (ValueType) obj;
+                final String valueToFindStr = serializationHelper.encode(valueToFind);
+                boolean found = false;
+                for (int i = 0; i < size(); i++) {
+                    String valueAtIndex = handle.jedis().lindex(key, i);
+                    if (valueToFindStr.equals(valueAtIndex)) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends ValueType> toAdd) {
+        try (final Handle handle = rdbi.open()) {
+            for (final ValueType value : toAdd) {
+                final String valueAsString = serializationHelper.encode(value);
+                handle.jedis().rpush(key, valueAsString);
+                if (size() >= maxSize) {
+                    handle.jedis().lpop(key);
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException("removeAll not supported by this circular buffer");
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException("retainAll not supported by this circular buffer");
+    }
+
+    @Override
+    public void clear() {
+        try (final Handle handle = rdbi.open()) {
+            handle.jedis().del(key);
+        }
+    }
+
+    @Override
+    public boolean offer(ValueType value) {
+        return addAll(ImmutableList.of(value));
+    }
+
+    @Override
+    public ValueType remove() {
+        try (final Handle handle = rdbi.open()) {
+            final String removedStr = handle.jedis().lpop(key);
+            if (removedStr == null) {
+                throw new NoSuchElementException("Circular buffer is empty, cannot remove");
+            }
+            final ValueType removedValue = serializationHelper.decode(removedStr);
+            return removedValue;
+        }
+    }
+
+    @Override
+    public ValueType poll() {
+        try (final Handle handle = rdbi.open()) {
+            final String removedStr = handle.jedis().lpop(key);
+            if (removedStr == null) {
+                return null;
+            }
+            final ValueType removedValue = serializationHelper.decode(removedStr);
+            return removedValue;
+        }
+    }
+
+    @Override
+    public ValueType element() {
+        try (final Handle handle = rdbi.open()) {
+            final String elementStr = handle.jedis().lindex(key, 0);
+            if (elementStr == null) {
+                throw new NoSuchElementException("Circular buffer is empty, cannot retrieve head");
+            }
+            final ValueType element = serializationHelper.decode(elementStr);
+            return element;
+        }
+    }
+
+    @Override
+    public ValueType peek() {
+        try (final Handle handle = rdbi.open()) {
+            final String removedStr = handle.jedis().lindex(key, 0);
+            if (removedStr == null) {
+                return null;
+            }
+            final ValueType removedValue = serializationHelper.decode(removedStr);
+            return removedValue;
+        }
+    }
+}

--- a/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBuffer.java
+++ b/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBuffer.java
@@ -144,13 +144,11 @@ public class RedisCircularBuffer<ValueType> implements Queue<ValueType> {
 
     @Override
     public ValueType remove() {
-        try (final Handle handle = rdbi.open()) {
-            final String removedStr = handle.jedis().lpop(key);
-            if (removedStr == null) {
-                throw new NoSuchElementException("Circular buffer is empty, cannot remove");
-            }
-            final ValueType removedValue = serializationHelper.decode(removedStr);
-            return removedValue;
+        ValueType element = remove();
+        if (element == null) {
+            throw new NoSuchElementException("Circular buffer is empty, cannot remove first element");
+        } else {
+            return element;
         }
     }
 
@@ -168,12 +166,10 @@ public class RedisCircularBuffer<ValueType> implements Queue<ValueType> {
 
     @Override
     public ValueType element() {
-        try (final Handle handle = rdbi.open()) {
-            final String elementStr = handle.jedis().lindex(key, 0);
-            if (elementStr == null) {
-                throw new NoSuchElementException("Circular buffer is empty, cannot retrieve head");
-            }
-            final ValueType element = serializationHelper.decode(elementStr);
+        ValueType element = peek();
+        if (element == null) {
+            throw new NoSuchElementException("Circular buffer is empty, cannot retrieve head");
+        } else {
             return element;
         }
     }

--- a/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBuffer.java
+++ b/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBuffer.java
@@ -2,25 +2,18 @@ package com.lithium.dbi.rdbi.recipes.queue;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.lithium.dbi.rdbi.Handle;
 import com.lithium.dbi.rdbi.RDBI;
 import com.lithium.dbi.rdbi.recipes.cache.SerializationHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import redis.clients.jedis.Pipeline;
-import redis.clients.jedis.Response;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Queue;
-import java.util.Set;
 
 import static java.util.stream.Collectors.toList;
 
@@ -109,7 +102,6 @@ public class RedisCircularBuffer<ValueType> implements Queue<ValueType> {
     @Override
     public boolean addAll(Collection<? extends ValueType> toAdd) {
         for (final ValueType value : toAdd) {
-            final String valueAsString = serializationHelper.encode(value);
             try (Handle handle = rdbi.open()) {
                 String valueStr = serializationHelper.encode(value);
                 final int newSize = handle.attach(RedisCircularBufferDAO.class).add(key, valueStr, maxSize);

--- a/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBuffer.java
+++ b/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBuffer.java
@@ -112,7 +112,7 @@ public class RedisCircularBuffer<ValueType> implements Queue<ValueType> {
             for (final ValueType value : toAdd) {
                 final String valueAsString = serializationHelper.encode(value);
                 handle.jedis().rpush(key, valueAsString);
-                if (size() >= maxSize) {
+                if (size() > maxSize) {
                     handle.jedis().lpop(key);
                 }
             }

--- a/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBuffer.java
+++ b/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBuffer.java
@@ -111,7 +111,7 @@ public class RedisCircularBuffer<ValueType> implements Queue<ValueType> {
             }
             pipeline.sync();
 
-            for(final Response<String> res : responses) {
+            for (final Response<String> res : responses) {
                 ValueType value = serializationHelper.decode(res.get());
                 currentSet.add(value);
             }
@@ -127,7 +127,7 @@ public class RedisCircularBuffer<ValueType> implements Queue<ValueType> {
             try (Handle handle = rdbi.open()) {
                 String valueStr = serializationHelper.encode(value);
                 final int newSize = handle.attach(RedisCircularBufferDAO.class).add(key, valueStr, maxSize);
-                boolean success =  newSize >= 0 && newSize <= maxSize;
+                boolean success = newSize >= 0 && newSize <= maxSize;
                 if (!success) {
                     return false;
                 }
@@ -214,7 +214,7 @@ public class RedisCircularBuffer<ValueType> implements Queue<ValueType> {
             }
             pipeline.sync();
 
-            for(final Response<String> res : responses) {
+            for (final Response<String> res : responses) {
                 ValueType value = serializationHelper.decode(res.get());
                 currentList.add(value);
             }

--- a/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBufferDAO.java
+++ b/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBufferDAO.java
@@ -8,14 +8,15 @@ public interface RedisCircularBufferDAO {
 
     @Query(
             "local size = redis.call('RPUSH', $key$, $valueToAdd$)\n" +
-                    "   if size > $maxSize$ then\n" +
-                    "       redis.call('LPOP', $key$)\n" +
-                    "   end\n" +
-                    "return true\n"
+                    "if size > tonumber($maxSize$) then\n" +
+                    "   redis.call('LPOP', $key$)\n" +
+                    "   size = size - 1\n" +
+                    "end\n" +
+                    "return size\n"
     )
-    boolean add(
+    int add(
             @BindKey("key") String key,
-            @BindArg("toAdd") String valueToAdd,
+            @BindArg("valueToAdd") String valueToAdd,
             @BindArg("maxSize") Integer maxSize);
 
 }

--- a/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBufferDAO.java
+++ b/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBufferDAO.java
@@ -1,0 +1,21 @@
+package com.lithium.dbi.rdbi.recipes.queue;
+
+import com.lithium.dbi.rdbi.BindArg;
+import com.lithium.dbi.rdbi.BindKey;
+import com.lithium.dbi.rdbi.Query;
+
+public interface RedisCircularBufferDAO {
+
+    @Query(
+            "local size = redis.call('RPUSH', $key$, $valueToAdd$)\n" +
+                    "   if size > $maxSize$ then\n" +
+                    "       redis.call('LPOP', $key$)\n" +
+                    "   end\n" +
+                    "return true\n"
+    )
+    boolean add(
+            @BindKey("key") String key,
+            @BindArg("toAdd") String valueToAdd,
+            @BindArg("maxSize") Integer maxSize);
+
+}

--- a/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBufferDAO.java
+++ b/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBufferDAO.java
@@ -9,7 +9,9 @@ public interface RedisCircularBufferDAO {
     @Query(
             "local size = redis.call('RPUSH', $key$, $valueToAdd$)\n" +
                     "if size > tonumber($maxSize$) then\n" +
-                    "   redis.call('LPOP', $key$)\n" +
+                    "   local start = size - tonumber($maxSize$)\n" +
+                    "   local stop = start + tonumber($maxSize$)\n" +
+                    "   redis.call('LTRIM', $key$, start, stop)\n" +
                     "   size = size - 1\n" +
                     "end\n" +
                     "return size\n"

--- a/rdbi-recipes/src/test/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBufferTest.java
+++ b/rdbi-recipes/src/test/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBufferTest.java
@@ -266,7 +266,7 @@ public class RedisCircularBufferTest {
 
     @Test
     public void basicPeekAllTest() {
-        final RedisCircularBuffer<UUID> circularBuffer = new RedisCircularBuffer(rdbi, circularBufferKey, 3, new UUIDSerialHelper());
+        final RedisCircularBuffer<UUID> circularBuffer = new RedisCircularBuffer(rdbi, circularBufferKey, 5, new UUIDSerialHelper());
 
         circularBuffer.clear();
         assertTrue(circularBuffer.isEmpty());

--- a/rdbi-recipes/src/test/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBufferTest.java
+++ b/rdbi-recipes/src/test/java/com/lithium/dbi/rdbi/recipes/queue/RedisCircularBufferTest.java
@@ -1,0 +1,126 @@
+package com.lithium.dbi.rdbi.recipes.queue;
+
+import com.google.common.collect.ImmutableList;
+import com.lithium.dbi.rdbi.RDBI;
+import com.lithium.dbi.rdbi.recipes.cache.SerializationHelper;
+import org.testng.annotations.Test;
+import redis.clients.jedis.JedisPool;
+
+import java.util.UUID;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = "integration")
+public class RedisCircularBufferTest {
+    public String circularBufferKey = "REDISCIRCULARBUFFER" + UUID.randomUUID().toString();
+    final RDBI rdbi = new RDBI(new JedisPool("localhost"));
+
+    public static class UUIDSerialHelper implements SerializationHelper<UUID> {
+
+        @Override
+        public UUID decode(String string) {
+            return UUID.fromString(string);
+        }
+
+        @Override
+        public String encode(UUID value) {
+            return value.toString();
+        }
+    }
+
+    @Test
+    public void getFromEmptyTest() {
+        final RedisCircularBuffer<UUID> circularBuffer = new RedisCircularBuffer(rdbi, circularBufferKey, 5, new UUIDSerialHelper());
+
+        circularBuffer.clear();
+        assertTrue(circularBuffer.isEmpty());
+    }
+
+    @Test
+    public void clearTest() {
+        final RedisCircularBuffer<UUID> circularBuffer = new RedisCircularBuffer(rdbi, circularBufferKey, 5, new UUIDSerialHelper());
+
+        circularBuffer.clear();
+        assertTrue(circularBuffer.isEmpty());
+
+        circularBuffer.add(UUID.randomUUID());
+        circularBuffer.add(UUID.randomUUID());
+        circularBuffer.add(UUID.randomUUID());
+
+        assertEquals(circularBuffer.size(), 3);
+
+        circularBuffer.clear();
+
+        assertEquals(circularBuffer.size(), 0);
+        assertTrue(circularBuffer.isEmpty());
+    }
+
+    @Test
+    public void bufferIsCircularTest() {
+        final RedisCircularBuffer<UUID> circularBuffer = new RedisCircularBuffer(rdbi, circularBufferKey, 5, new UUIDSerialHelper());
+
+        circularBuffer.clear();
+        assertTrue(circularBuffer.isEmpty());
+
+        final UUID first = UUID.randomUUID();
+        final UUID second = UUID.randomUUID();
+        final UUID third = UUID.randomUUID();
+        final UUID fourth = UUID.randomUUID();
+        final UUID fifth = UUID.randomUUID();
+        final UUID sixth = UUID.randomUUID();
+
+        circularBuffer.addAll(ImmutableList.of(first, second, third, fourth, fifth, sixth));
+
+        assertTrue(circularBuffer.containsAll(ImmutableList.of(second, third, fourth, fifth, sixth)));
+        assertFalse(circularBuffer.contains(first));
+
+        circularBuffer.clear();
+        assertTrue(circularBuffer.isEmpty());
+    }
+
+    @Test
+    public void basicOperationTest() {
+        final RedisCircularBuffer<UUID> circularBuffer = new RedisCircularBuffer(rdbi, circularBufferKey, 5, new UUIDSerialHelper());
+
+        circularBuffer.clear();
+        assertTrue(circularBuffer.isEmpty());
+
+        final UUID first = UUID.randomUUID();
+        final UUID second = UUID.randomUUID();
+        final UUID third = UUID.randomUUID();
+
+        circularBuffer.addAll(ImmutableList.of(first));
+        circularBuffer.addAll(ImmutableList.of(second,third));
+
+        assertTrue(circularBuffer.containsAll(ImmutableList.of(first, second, third)));
+
+        circularBuffer.remove(second);
+
+        assertFalse(circularBuffer.contains(second));
+        assertTrue(circularBuffer.contains(third));
+        assertFalse(circularBuffer.containsAll(ImmutableList.of(first, second)));
+        assertTrue(circularBuffer.containsAll(ImmutableList.of(first, third)));
+
+//        assertEquals(circularBuffer.size(), 2);
+//
+//        assertEquals(circularBuffer.popRange(0, 10), ImmutableList.of(new RedisCircularBuffer.ValueWithScore<>(first, 9),
+//                                                           new RedisCircularBuffer.ValueWithScore<>(third, 10)));
+//
+//        assertTrue(circularBuffer.isEmpty());
+//
+//        circularBuffer.addAll(ImmutableList.of(second), 5);
+//        circularBuffer.add(third);
+//        circularBuffer.addAll(ImmutableList.of(first), 0);
+//
+//        assertEquals(circularBuffer.popRange(0, 0),
+//                     ImmutableList.of(new RedisCircularBuffer.ValueWithScore<>(first, 0)));
+//
+//        assertEquals(circularBuffer.popRange(1, 1),
+//                     ImmutableList.of(new RedisCircularBuffer.ValueWithScore<>(third, 10)));
+
+        circularBuffer.clear();
+        assertTrue(circularBuffer.isEmpty());
+    }
+}


### PR DESCRIPTION
Still testing

Considered pipelining then trimming the list for addAll, but ultimately decided to maintain the list at "maxSize" -- not sure which way is actually better for performance/how much storage is being used

Did not implement removeAll(collection), retainAll(collection), iterator(), toArray(), toArray(array), remove(object) -- are they necessary?