### PR TITLE
CARE-16897 Add scheduleReader

### DIFF
--- a/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/scheduler/MultiChannelScheduler.java
+++ b/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/scheduler/MultiChannelScheduler.java
@@ -1,13 +1,10 @@
 package com.lithium.dbi.rdbi.recipes.scheduler;
 
-import com.google.common.primitives.Ints;
 import com.lithium.dbi.rdbi.Handle;
 import com.lithium.dbi.rdbi.RDBI;
 import redis.clients.jedis.resps.Tuple;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
@@ -342,11 +339,6 @@ public class MultiChannelScheduler {
         return rdbi.withHandle(handle -> handle.jedis().zcount(queue, 0, clock.getAsLong()));
     }
 
-    public long getRunningJobCount(String tube) {
-        final String queue = getRunningQueue(tube);
-        return rdbi.withHandle(handle -> handle.jedis().zcard(queue));
-    }
-
     /**
      * returns a list of jobs scheduled with a delay - to run in the future
      */
@@ -364,14 +356,6 @@ public class MultiChannelScheduler {
 
     public List<TimeJobInfo> peekExpired(String tube, int offset, int count) {
         return peekInternal(getRunningQueue(tube), 0.0d, (double) clock.getAsLong(), offset, count);
-    }
-
-    public Integer getRunningCountForChannel(String channel, String tube) {
-        final String key = getRunningCountKey(channel, tube);
-        final String count = rdbi.withHandle(h -> h.jedis().get(key));
-        return Optional.ofNullable(count)
-                       .map(Ints::tryParse)
-                       .orElse(0);
     }
 
     private List<TimeJobInfo> peekInternal(String queue, Double min, Double max, int offset, int count) {

--- a/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/scheduler/MultiChannelScheduler.java
+++ b/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/scheduler/MultiChannelScheduler.java
@@ -153,15 +153,6 @@ public class MultiChannelScheduler {
         }
     }
 
-    public long getAllReadyJobCount(String tube) {
-        try (Handle handle = rdbi.open()) {
-            return handle.attach(MultiChannelSchedulerDAO.class)
-                         .getAllReadyJobCount(
-                                 getMultiChannelCircularBuffer(tube),
-                                 clock.getAsLong());
-        }
-    }
-
     /**
      * See {@link StateDedupedJobScheduler#ackJob(java.lang.String, java.lang.String)}
      */
@@ -332,11 +323,6 @@ public class MultiChannelScheduler {
             handle.jedis().del(getPausedKey(channel, tube));
             return null;
         });
-    }
-
-    public long getReadyJobCount(String channel, String tube) {
-        final String queue = getReadyQueue(channel, tube);
-        return rdbi.withHandle(handle -> handle.jedis().zcount(queue, 0, clock.getAsLong()));
     }
 
     /**

--- a/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/scheduler/ScheduleReader.java
+++ b/rdbi-recipes/src/main/java/com/lithium/dbi/rdbi/recipes/scheduler/ScheduleReader.java
@@ -1,0 +1,76 @@
+package com.lithium.dbi.rdbi.recipes.scheduler;
+
+import java.util.Optional;
+import java.util.function.LongSupplier;
+import com.google.common.primitives.Ints;
+import com.lithium.dbi.rdbi.Handle;
+import com.lithium.dbi.rdbi.RDBI;
+
+/**
+ * Designed to read schedules from a data store, particularly redis. We need to break off reading
+ * to a separate class so clients can safely use a read replica. Derived from {@link MultiChannelScheduler}
+ */
+public class ScheduleReader {
+    protected final RDBI rdbi;
+    protected final String prefix;
+    protected final LongSupplier clock;
+
+    public ScheduleReader(RDBI rdbi, String prefix, LongSupplier clock) {
+        this.rdbi = rdbi;
+        this.prefix = prefix;
+        this.clock = clock;
+    }
+
+    public ScheduleReader(RDBI rdbi, String prefix) {
+        this(rdbi, prefix, System::currentTimeMillis);
+    }
+
+    public long getAllReadyJobCount(String tube) {
+        try (Handle handle = rdbi.open()) {
+            return handle.attach(MultiChannelSchedulerDAO.class)
+                    .getAllReadyJobCount(
+                            getMultiChannelCircularBuffer(tube),
+                            clock.getAsLong());
+        }
+    }
+
+    public long getReadyJobCount(String channel, String tube) {
+        final String queue = getReadyQueue(channel, tube);
+        return rdbi.withHandle(handle -> handle.jedis().zcount(queue, 0, clock.getAsLong()));
+    }
+
+    public long getRunningJobCount(String tube) {
+        final String queue = getRunningQueue(tube);
+        return rdbi.withHandle(handle -> handle.jedis().zcard(queue));
+    }
+
+    public Integer getRunningCountForChannel(String channel, String tube) {
+        final String key = getRunningCountKey(channel, tube);
+        final String count = rdbi.withHandle(h -> h.jedis().get(key));
+        return Optional.ofNullable(count)
+                .map(Ints::tryParse)
+                .orElse(0);
+    }
+
+    private String getMultiChannelCircularBuffer(String tube) {
+        return prefix + ":multichannel:" + tube + ":circular_buffer";
+    }
+
+    private String getTubePrefix(String channel, String tube) {
+        return prefix + ":" + channel + ":" + tube;
+    }
+
+    private String getReadyQueue(String channel, String tube) {
+        return getTubePrefix(channel, tube) + ":ready_queue";
+    }
+
+    private String getRunningQueue(String tube) {
+        return prefix + ":multichannel:" + tube + ":running_queue";
+    }
+
+    private String getRunningCountKey(String channel, String tube) {
+        return getTubePrefix(channel, tube) + ":running_count";
+    }
+
+
+}

--- a/rdbi-recipes/src/test/java/com/lithium/dbi/rdbi/recipes/scheduler/MultiChannelSchedulerTest.java
+++ b/rdbi-recipes/src/test/java/com/lithium/dbi/rdbi/recipes/scheduler/MultiChannelSchedulerTest.java
@@ -210,12 +210,12 @@ public class MultiChannelSchedulerTest {
         scheduledJobSystem.schedule(channel1, tube1, jobId + "_2", 0);
         scheduledJobSystem.schedule(channel1, tube1, jobId + "_3", 0);
 
-        assertThat(scheduledJobSystem.getAllReadyJobCount(tube1)).isEqualTo(3);
+        assertThat(scheduleReader.getAllReadyJobCount(tube1)).isEqualTo(3);
 
         List<TimeJobInfo> infos = scheduledJobSystem.reserveMulti(tube1, 1_000L, 3);
 
         assertThat(infos).hasSize(3);
-        assertThat(scheduledJobSystem.getAllReadyJobCount(tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getAllReadyJobCount(tube1)).isEqualTo(0);
         assertThat(scheduleReader.getRunningJobCount(tube1)).isEqualTo(3);
     }
 
@@ -253,9 +253,9 @@ public class MultiChannelSchedulerTest {
         String jobId = "C" + ":" + tube1 + "_bleh";
         assertThat(scheduledJobSystem.schedule("C", tube1, jobId, 0)).isTrue();
 
-        assertThat(scheduledJobSystem.getReadyJobCount("A", tube1)).isEqualTo(10);
-        assertThat(scheduledJobSystem.getReadyJobCount("B", tube1)).isEqualTo(5);
-        assertThat(scheduledJobSystem.getReadyJobCount("C", tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getReadyJobCount("A", tube1)).isEqualTo(10);
+        assertThat(scheduleReader.getReadyJobCount("B", tube1)).isEqualTo(5);
+        assertThat(scheduleReader.getReadyJobCount("C", tube1)).isEqualTo(1);
 
         assertThat(scheduleReader.getRunningCountForChannel("A", tube1)).isEqualTo(0);
         assertThat(scheduleReader.getRunningCountForChannel("B", tube1)).isEqualTo(0);
@@ -483,7 +483,7 @@ public class MultiChannelSchedulerTest {
         assertThat(scheduledJobSystem.reserveMulti(tube1, 1000L, 1)).hasSize(1);
         assertThat(scheduledJobSystem.reserveMulti(tube1, 1000L, 1)).hasSize(1);
 
-        assertThat(scheduledJobSystem.getAllReadyJobCount(tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getAllReadyJobCount(tube1)).isEqualTo(0);
         assertThat(scheduleReader.getRunningJobCount(tube1)).isEqualTo(3);
     }
 
@@ -619,7 +619,7 @@ public class MultiChannelSchedulerTest {
         scheduledJobSystem.schedule("B", tube1, jobId + "_2", 0);
         scheduledJobSystem.schedule("C", tube1, jobId + "_3", 0);
 
-        assertThat(scheduledJobSystem.getAllReadyJobCount(tube1)).isEqualTo(3);
+        assertThat(scheduleReader.getAllReadyJobCount(tube1)).isEqualTo(3);
 
     }
 
@@ -628,23 +628,24 @@ public class MultiChannelSchedulerTest {
 
         TestClock clock = new TestClock(System.currentTimeMillis(), 10);
         MultiChannelScheduler scheduledJobSystem  = new MultiChannelScheduler(rdbi, prefix, clock);
+        ScheduleReader scheduleReader = new ScheduleReader(rdbi, prefix, clock);
 
         // Schedule a job
         scheduledJobSystem.schedule("A", tube1, "{hello:world}", 20);
 
         // we should not count it as 'ready'
-        assertThat(scheduledJobSystem.getReadyJobCount("A", tube1)).isEqualTo(0);
-        assertThat(scheduledJobSystem.getAllReadyJobCount(tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getReadyJobCount("A", tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getAllReadyJobCount(tube1)).isEqualTo(0);
 
         clock.tick();
         // we should not count it as 'ready'
-        assertThat(scheduledJobSystem.getReadyJobCount("A", tube1)).isEqualTo(0);
-        assertThat(scheduledJobSystem.getAllReadyJobCount(tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getReadyJobCount("A", tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getAllReadyJobCount(tube1)).isEqualTo(0);
 
         clock.tick();
         // we should now count it as 'ready'
-        assertThat(scheduledJobSystem.getReadyJobCount("A", tube1)).isEqualTo(1);
-        assertThat(scheduledJobSystem.getAllReadyJobCount(tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getReadyJobCount("A", tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getAllReadyJobCount(tube1)).isEqualTo(1);
     }
 
     @Test

--- a/rdbi-recipes/src/test/java/com/lithium/dbi/rdbi/recipes/scheduler/MultiChannelSchedulerTest.java
+++ b/rdbi-recipes/src/test/java/com/lithium/dbi/rdbi/recipes/scheduler/MultiChannelSchedulerTest.java
@@ -21,6 +21,8 @@ public class MultiChannelSchedulerTest {
     private String tube1 = "tube1";
     private String channel1 = "channel1";
 
+    private final ScheduleReader scheduleReader = new ScheduleReader(rdbi, prefix);
+
     @AfterMethod
     public void tearDown() {
         try (Handle handle = rdbi.open()) {
@@ -62,15 +64,15 @@ public class MultiChannelSchedulerTest {
 
         assertThat(job2).isEmpty();
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(1);
         boolean ack1 = scheduledJobSystem.ackJob(channel1, tube1, job1.get(0).getJobStr());
 
         assertThat(ack1).isTrue();
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
         ack1 = scheduledJobSystem.ackJob(channel1, tube1, job1.get(0).getJobStr());
         assertThat(ack1).isFalse();
         // no negative
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
 
     }
 
@@ -85,7 +87,7 @@ public class MultiChannelSchedulerTest {
         scheduledJobSystem.reserveMulti(tube1, 1000, 1);
 
         // we aren't tracking yet
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
 
         // now enable
         assertThat(scheduledJobSystem.enablePerChannelTracking()).isTrue();
@@ -95,18 +97,18 @@ public class MultiChannelSchedulerTest {
         assertThat(scheduledJobSystem.isPerChannelTrackingEnabled()).isTrue();
 
         // we don't automagically track things that were already running
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
 
         scheduledJobSystem.ackJob(channel1, tube1, jobId);
 
         // even though we're tracking, negatives can't happen
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
 
         scheduledJobSystem.schedule(channel1, tube1, jobId, 0);
         scheduledJobSystem.reserveMulti(tube1, 1000, 1);
 
         // we are tracking now
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(1);
 
         // now disable
         assertThat(scheduledJobSystem.disablePerChannelTracking()).isTrue();
@@ -116,13 +118,13 @@ public class MultiChannelSchedulerTest {
         assertThat(scheduledJobSystem.isPerChannelTrackingEnabled()).isFalse();
 
         // we can't automagically untrack things
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(1);
 
 
         scheduledJobSystem.ackJob(channel1, tube1, jobId);
 
         // even though we're not tracking anymore we still decrement on exit
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
     }
 
     @Test
@@ -134,16 +136,16 @@ public class MultiChannelSchedulerTest {
         scheduledJobSystem.schedule(channel1, tube1, jobId, 0);
         scheduledJobSystem.reserveMulti(tube1, 1000, 1);
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(1);
 
         // artificially decrement
         rdbi.withHandle(h -> h.jedis().decr(prefix + ":" + channel1 + ":" + tube1 + ":running_count"));
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
 
         scheduledJobSystem.ackJob(channel1, tube1, jobId);
         // not negative
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
     }
 
     @Test
@@ -157,20 +159,20 @@ public class MultiChannelSchedulerTest {
         scheduledJobSystem.schedule(channel1, tube1, jobId, 0);
         scheduledJobSystem.reserveMulti(tube1, 1000, 1);
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(1);
 
         scheduledJobSystem.schedule(channel1, tube1, jobId2, 0);
         scheduledJobSystem.reserveMulti(tube1, 1000, 1);
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(2);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(2);
 
         scheduledJobSystem.ackJob(channel1, tube1, jobId);
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(1);
 
         scheduledJobSystem.ackJob(channel1, tube1, jobId2);
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
         boolean exists = rdbi.withHandle(h -> h.jedis().exists(prefix + ":" + channel1 + ":" + tube1 + ":running_count"));
         assertThat(exists).isFalse();
     }
@@ -184,16 +186,16 @@ public class MultiChannelSchedulerTest {
         scheduledJobSystem.schedule(channel1, tube1, jobId, 0);
         scheduledJobSystem.reserveMulti(tube1, 1000, 1);
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(1);
 
         // artificially remove
         rdbi.withHandle(h -> h.jedis().del(prefix + ":" + channel1 + ":" + tube1 + ":running_count"));
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
 
         scheduledJobSystem.ackJob(channel1, tube1, jobId);
         // not negative
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
     }
 
 
@@ -214,7 +216,7 @@ public class MultiChannelSchedulerTest {
 
         assertThat(infos).hasSize(3);
         assertThat(scheduledJobSystem.getAllReadyJobCount(tube1)).isEqualTo(0);
-        assertThat(scheduledJobSystem.getRunningJobCount(tube1)).isEqualTo(3);
+        assertThat(scheduleReader.getRunningJobCount(tube1)).isEqualTo(3);
     }
 
     @Test
@@ -255,9 +257,9 @@ public class MultiChannelSchedulerTest {
         assertThat(scheduledJobSystem.getReadyJobCount("B", tube1)).isEqualTo(5);
         assertThat(scheduledJobSystem.getReadyJobCount("C", tube1)).isEqualTo(1);
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel("A", tube1)).isEqualTo(0);
-        assertThat(scheduledJobSystem.getRunningCountForChannel("B", tube1)).isEqualTo(0);
-        assertThat(scheduledJobSystem.getRunningCountForChannel("C", tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel("A", tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel("B", tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel("C", tube1)).isEqualTo(0);
 
         final Consumer<String> reserveAndAssert = channel -> {
             List<TimeJobInfo> job1 = scheduledJobSystem.reserveMulti(tube1, 1000, 1);
@@ -275,9 +277,9 @@ public class MultiChannelSchedulerTest {
         reserveAndAssert.accept("B");
         reserveAndAssert.accept("C");
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel("A", tube1)).isEqualTo(1);
-        assertThat(scheduledJobSystem.getRunningCountForChannel("B", tube1)).isEqualTo(1);
-        assertThat(scheduledJobSystem.getRunningCountForChannel("C", tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getRunningCountForChannel("A", tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getRunningCountForChannel("B", tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getRunningCountForChannel("C", tube1)).isEqualTo(1);
 
 
         assertThat(scheduledJobSystem.getAllReadyChannels(tube1))
@@ -295,9 +297,9 @@ public class MultiChannelSchedulerTest {
         reserveAndAssert.accept("A");
         reserveAndAssert.accept("B");
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel("A", tube1)).isEqualTo(5);
-        assertThat(scheduledJobSystem.getRunningCountForChannel("B", tube1)).isEqualTo(5);
-        assertThat(scheduledJobSystem.getRunningCountForChannel("C", tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getRunningCountForChannel("A", tube1)).isEqualTo(5);
+        assertThat(scheduleReader.getRunningCountForChannel("B", tube1)).isEqualTo(5);
+        assertThat(scheduleReader.getRunningCountForChannel("C", tube1)).isEqualTo(1);
 
 
         assertThat(scheduledJobSystem.getAllReadyChannels(tube1))
@@ -306,9 +308,9 @@ public class MultiChannelSchedulerTest {
         reserveAndAssert.accept("A");
         reserveAndAssert.accept("A");
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel("A", tube1)).isEqualTo(7);
-        assertThat(scheduledJobSystem.getRunningCountForChannel("B", tube1)).isEqualTo(5);
-        assertThat(scheduledJobSystem.getRunningCountForChannel("C", tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getRunningCountForChannel("A", tube1)).isEqualTo(7);
+        assertThat(scheduleReader.getRunningCountForChannel("B", tube1)).isEqualTo(5);
+        assertThat(scheduleReader.getRunningCountForChannel("C", tube1)).isEqualTo(1);
 
         // now we have only A jobs with 3 remaining.
         // if we schedule a C job now, it should run
@@ -324,9 +326,9 @@ public class MultiChannelSchedulerTest {
         reserveAndAssert.accept("A");
         reserveAndAssert.accept("C");
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel("A", tube1)).isEqualTo(8);
-        assertThat(scheduledJobSystem.getRunningCountForChannel("B", tube1)).isEqualTo(5);
-        assertThat(scheduledJobSystem.getRunningCountForChannel("C", tube1)).isEqualTo(2);
+        assertThat(scheduleReader.getRunningCountForChannel("A", tube1)).isEqualTo(8);
+        assertThat(scheduleReader.getRunningCountForChannel("B", tube1)).isEqualTo(5);
+        assertThat(scheduleReader.getRunningCountForChannel("C", tube1)).isEqualTo(2);
 
         assertThat(scheduledJobSystem.getAllReadyChannels(tube1))
                 .containsExactlyInAnyOrder("A");
@@ -334,14 +336,14 @@ public class MultiChannelSchedulerTest {
         reserveAndAssert.accept("A");
         reserveAndAssert.accept("A");
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel("A", tube1)).isEqualTo(10);
-        assertThat(scheduledJobSystem.getRunningCountForChannel("B", tube1)).isEqualTo(5);
-        assertThat(scheduledJobSystem.getRunningCountForChannel("C", tube1)).isEqualTo(2);
+        assertThat(scheduleReader.getRunningCountForChannel("A", tube1)).isEqualTo(10);
+        assertThat(scheduleReader.getRunningCountForChannel("B", tube1)).isEqualTo(5);
+        assertThat(scheduleReader.getRunningCountForChannel("C", tube1)).isEqualTo(2);
 
         assertThat(scheduledJobSystem.getAllReadyChannels(tube1))
                 .isEmpty();
 
-        assertThat(scheduledJobSystem.getRunningJobCount(tube1)).isEqualTo(17);
+        assertThat(scheduleReader.getRunningJobCount(tube1)).isEqualTo(17);
 
     }
 
@@ -395,7 +397,7 @@ public class MultiChannelSchedulerTest {
 
         assertThat(scheduledJobSystem.removeExpiredRunningJobsAndDecrementCount(tube1, tjiToChannel)).hasSize(1);
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel(channel1, tube1)).isEqualTo(0);
         boolean exists = rdbi.withHandle(h -> h.jedis().exists(prefix + ":" + channel1 + ":" + tube1 + ":running_count"));
         assertThat(exists).isFalse();
     }
@@ -482,7 +484,7 @@ public class MultiChannelSchedulerTest {
         assertThat(scheduledJobSystem.reserveMulti(tube1, 1000L, 1)).hasSize(1);
 
         assertThat(scheduledJobSystem.getAllReadyJobCount(tube1)).isEqualTo(0);
-        assertThat(scheduledJobSystem.getRunningJobCount(tube1)).isEqualTo(3);
+        assertThat(scheduleReader.getRunningJobCount(tube1)).isEqualTo(3);
     }
 
 
@@ -659,7 +661,7 @@ public class MultiChannelSchedulerTest {
         assertThat(scheduledJobSystem.inReadyQueue("A", tube1, jobId)).isFalse();
 
         assertThat(scheduledJobSystem.deleteJob("A", tube1, jobId)).isTrue();
-        assertThat(scheduledJobSystem.getRunningCountForChannel("A", tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel("A", tube1)).isEqualTo(0);
     }
 
     @Test
@@ -677,12 +679,12 @@ public class MultiChannelSchedulerTest {
         assertThat(scheduledJobSystem.inRunningQueue(tube1, jobId)).isTrue();
         assertThat(scheduledJobSystem.inReadyQueue("A", tube1, jobId)).isTrue();
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel("A", tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getRunningCountForChannel("A", tube1)).isEqualTo(1);
         assertThat(scheduledJobSystem.deleteJob("A", tube1, jobId)).isTrue();
-        assertThat(scheduledJobSystem.getRunningCountForChannel("A", tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel("A", tube1)).isEqualTo(0);
 
         assertThat(scheduledJobSystem.deleteJob("A", tube1, jobId)).isFalse();
-        assertThat(scheduledJobSystem.getRunningCountForChannel("A", tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel("A", tube1)).isEqualTo(0);
 
 
         // submit & reserve a job in another channel to make sure we cleaned up internal state
@@ -698,8 +700,8 @@ public class MultiChannelSchedulerTest {
                 .hasSize(1)
                 .extracting(JobInfo::getJobStr)
                 .containsExactly(jobId + "_1");
-        assertThat(scheduledJobSystem.getRunningCountForChannel("A", tube1)).isEqualTo(0);
-        assertThat(scheduledJobSystem.getRunningCountForChannel("B", tube1)).isEqualTo(1);
+        assertThat(scheduleReader.getRunningCountForChannel("A", tube1)).isEqualTo(0);
+        assertThat(scheduleReader.getRunningCountForChannel("B", tube1)).isEqualTo(1);
 
     }
 
@@ -923,7 +925,7 @@ public class MultiChannelSchedulerTest {
 
         List<TimeJobInfo> reserved = scheduledJobSystem.reserveMulti(tube1, 1_000L, 3, 0, 2);
 
-        System.out.println(scheduledJobSystem.getRunningCountForChannel("A", tube1));
+        System.out.println(scheduleReader.getRunningCountForChannel("A", tube1));
         // we reserved 2 from a1 channel then hit our limit
         assertThat(reserved)
                 .hasSize(3)
@@ -931,7 +933,7 @@ public class MultiChannelSchedulerTest {
                 .containsExactly(jobId + "_A1", jobId + "_A2", jobId + "_B1");
 
 
-        assertThat(scheduledJobSystem.getRunningCountForChannel("A", tube1)).isEqualTo(2);
+        assertThat(scheduleReader.getRunningCountForChannel("A", tube1)).isEqualTo(2);
 
         reserved = scheduledJobSystem.reserveMulti(tube1, 1_0000L, 2, 0, 2);
         // tried to reserve 2 but, should get none for A but the one for C


### PR DESCRIPTION
https://jira.dev.lithium.com/browse/CARE-16897

Part of the effort to use the read-only replicas. The MultiChannelScheduler is only used in Omega, and only in a few places. Breaking off some of the calls that are used for analytics so we can use a reader replica instead.